### PR TITLE
CAN bus patch for D1s/T113

### DIFF
--- a/linux/d1s_t113_can_bus.patch
+++ b/linux/d1s_t113_can_bus.patch
@@ -1,0 +1,173 @@
+diff --git a/drivers/clk/sunxi-ng/ccu-sun20i-d1.c b/drivers/clk/sunxi-ng/ccu-sun20i-d1.c
+index 8ef3cdeb7962..6c960942eaef 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun20i-d1.c
++++ b/drivers/clk/sunxi-ng/ccu-sun20i-d1.c
+@@ -469,6 +469,13 @@ static SUNXI_CCU_GATE_HWS(bus_i2c2_clk, "bus-i2c2", apb1_hws,
+ static SUNXI_CCU_GATE_HWS(bus_i2c3_clk, "bus-i2c3", apb1_hws,
+ 			  0x91c, BIT(3), 0);
+ 
++static SUNXI_CCU_GATE_HWS(bus_can0_clk, "bus-can0", apb1_hws,
++			  0x92, BIT(0), 0);
++static SUNXI_CCU_GATE_HWS(bus_can1_clk, "bus-can1", apb1_hws,
++			  0x92, BIT(1), 0);
++
++
++
+ static const struct clk_parent_data spi_parents[] = {
+ 	{ .fw_name = "hosc" },
+ 	{ .hw = &pll_periph0_clk.hw },
+@@ -997,6 +1004,8 @@ static struct ccu_common *sun20i_d1_ccu_clks[] = {
+ 	&bus_i2c1_clk.common,
+ 	&bus_i2c2_clk.common,
+ 	&bus_i2c3_clk.common,
++	&bus_can0_clk.common,
++	&bus_can1_clk.common,
+ 	&spi0_clk.common,
+ 	&spi1_clk.common,
+ 	&bus_spi0_clk.common,
+@@ -1147,6 +1156,8 @@ static struct clk_hw_onecell_data sun20i_d1_hw_clks = {
+ 		[CLK_BUS_I2C1]		= &bus_i2c1_clk.common.hw,
+ 		[CLK_BUS_I2C2]		= &bus_i2c2_clk.common.hw,
+ 		[CLK_BUS_I2C3]		= &bus_i2c3_clk.common.hw,
++		[CLK_BUS_CAN0]		= &bus_can0_clk.common.hw,
++		[CLK_BUS_CAN1]		= &bus_can1_clk.common.hw,
+ 		[CLK_SPI0]		= &spi0_clk.common.hw,
+ 		[CLK_SPI1]		= &spi1_clk.common.hw,
+ 		[CLK_BUS_SPI0]		= &bus_spi0_clk.common.hw,
+@@ -1252,6 +1263,8 @@ static struct ccu_reset_map sun20i_d1_ccu_resets[] = {
+ 	[RST_BUS_I2C1]		= { 0x91c, BIT(17) },
+ 	[RST_BUS_I2C2]		= { 0x91c, BIT(18) },
+ 	[RST_BUS_I2C3]		= { 0x91c, BIT(19) },
++	[RST_BUS_CAN0]		= { 0x92c, BIT(16) },
++	[RST_BUS_CAN1]		= { 0x92c, BIT(17) },
+ 	[RST_BUS_SPI0]		= { 0x96c, BIT(16) },
+ 	[RST_BUS_SPI1]		= { 0x96c, BIT(17) },
+ 	[RST_BUS_EMAC]		= { 0x97c, BIT(16) },
+diff --git a/drivers/net/can/sun4i_can.c b/drivers/net/can/sun4i_can.c
+index 525309da1320..0922f59f6bbe 100644
+--- a/drivers/net/can/sun4i_can.c
++++ b/drivers/net/can/sun4i_can.c
+@@ -89,8 +89,6 @@
+ #define SUN4I_REG_BUF10_ADDR	0x0068	/* CAN Tx/Rx Buffer 10 */
+ #define SUN4I_REG_BUF11_ADDR	0x006c	/* CAN Tx/Rx Buffer 11 */
+ #define SUN4I_REG_BUF12_ADDR	0x0070	/* CAN Tx/Rx Buffer 12 */
+-#define SUN4I_REG_ACPC_ADDR	0x0040	/* CAN Acceptance Code 0 */
+-#define SUN4I_REG_ACPM_ADDR	0x0044	/* CAN Acceptance Mask 0 */
+ #define SUN4I_REG_RBUF_RBACK_START_ADDR	0x0180	/* CAN transmit buffer start */
+ #define SUN4I_REG_RBUF_RBACK_END_ADDR	0x01b0	/* CAN transmit buffer end */
+ 
+@@ -201,6 +199,15 @@
+ #define SUN4I_CAN_MAX_IRQ	20
+ #define SUN4I_MODE_MAX_RETRIES	100
+ 
++/**
++ * struct sun4ican_addresses - Different register addresses for some SoCs.
++ *
++ */
++struct sun4ican_addresses {
++	unsigned int can_acceptance_code;
++	unsigned int can_acceptance_mask;
++};
++
+ /**
+  * struct sun4ican_quirks - Differences between SoC variants.
+  *
+@@ -208,6 +215,7 @@
+  */
+ struct sun4ican_quirks {
+ 	bool has_reset;
++	struct sun4ican_addresses addresses;
+ };
+ 
+ struct sun4ican_priv {
+@@ -216,6 +224,7 @@ struct sun4ican_priv {
+ 	struct clk *clk;
+ 	struct reset_control *reset;
+ 	spinlock_t cmdreg_lock;	/* lock for concurrent cmd register writes */
++	struct sun4ican_addresses addresses;
+ };
+ 
+ static const struct can_bittiming_const sun4ican_bittiming_const = {
+@@ -338,8 +347,8 @@ static int sun4i_can_start(struct net_device *dev)
+ 	}
+ 
+ 	/* set filters - we accept all */
+-	writel(0x00000000, priv->base + SUN4I_REG_ACPC_ADDR);
+-	writel(0xFFFFFFFF, priv->base + SUN4I_REG_ACPM_ADDR);
++	writel(0x00000000, priv->base + priv->addresses.can_acceptance_code);
++	writel(0xFFFFFFFF, priv->base + priv->addresses.can_acceptance_mask);
+ 
+ 	/* clear error counters and error code capture */
+ 	writel(0, priv->base + SUN4I_REG_ERRC_ADDR);
+@@ -768,10 +777,26 @@ static const struct ethtool_ops sun4ican_ethtool_ops = {
+ 
+ static const struct sun4ican_quirks sun4ican_quirks_a10 = {
+ 	.has_reset = false,
++	.addresses = {
++		.can_acceptance_code = 0x0040,
++		.can_acceptance_mask = 0x0044,
++	}
+ };
+ 
+ static const struct sun4ican_quirks sun4ican_quirks_r40 = {
+ 	.has_reset = true,
++	.addresses = {
++		.can_acceptance_code = 0x0040,
++		.can_acceptance_mask = 0x0044,
++	}
++};
++
++static const struct sun4ican_quirks sun4ican_quirks_d1s = {
++	.has_reset = true,
++	.addresses = {
++		.can_acceptance_code = 0x0028,
++		.can_acceptance_mask = 0x002c,
++	}
+ };
+ 
+ static const struct of_device_id sun4ican_of_match[] = {
+@@ -784,6 +809,12 @@ static const struct of_device_id sun4ican_of_match[] = {
+ 	}, {
+ 		.compatible = "allwinner,sun8i-r40-can",
+ 		.data = &sun4ican_quirks_r40
++	}, {
++		.compatible = "allwinner,sun8i-d1s-can",
++		.data = &sun4ican_quirks_d1s
++	}, {
++		.compatible = "allwinner,sun8i-t113-s3-can",
++		.data = &sun4ican_quirks_d1s
+ 	}, {
+ 		/* sentinel */
+ 	},
+@@ -909,4 +940,4 @@ module_platform_driver(sun4i_can_driver);
+ MODULE_AUTHOR("Peter Chen <xingkongcp@gmail.com>");
+ MODULE_AUTHOR("Gerhard Bertelsmann <info@gerhard-bertelsmann.de>");
+ MODULE_LICENSE("Dual BSD/GPL");
+-MODULE_DESCRIPTION("CAN driver for Allwinner SoCs (A10/A20)");
++MODULE_DESCRIPTION("CAN driver for Allwinner SoCs (A10/A20/D1S/T113-S3)");
+diff --git a/include/dt-bindings/clock/sun20i-d1-ccu.h b/include/dt-bindings/clock/sun20i-d1-ccu.h
+index e3ac53315e1a..ccfef2327794 100644
+--- a/include/dt-bindings/clock/sun20i-d1-ccu.h
++++ b/include/dt-bindings/clock/sun20i-d1-ccu.h
+@@ -153,4 +153,8 @@
+ #define CLK_FANOUT1		143
+ #define CLK_FANOUT2		144
+ 
++// Separate to avoid issues when clocks get added
++#define CLK_BUS_CAN0		200
++#define CLK_BUS_CAN1		201
++
+ #endif /* _DT_BINDINGS_CLK_SUN20I_D1_CCU_H_ */
+diff --git a/include/dt-bindings/reset/sun20i-d1-ccu.h b/include/dt-bindings/reset/sun20i-d1-ccu.h
+index de9ff5203239..6396b3816900 100644
+--- a/include/dt-bindings/reset/sun20i-d1-ccu.h
++++ b/include/dt-bindings/reset/sun20i-d1-ccu.h
+@@ -74,4 +74,8 @@
+ #define RST_BUS_DSP_DBG		64
+ #define RST_BUS_RISCV_CFG	65
+ 
++// Separate to avoid issues when clocks get added
++#define RST_BUS_CAN0		200
++#define RST_BUS_CAN1		201
++
+ #endif /* _DT_BINDINGS_RST_SUN20I_D1_CCU_H_ */


### PR DESCRIPTION
Made this patch for can bus based on what I've found on a chinese [forum post](https://bbs.aw-ol.com/topic/1926/t113-s3-can-linux-%E4%B8%8B%E5%B7%B2%E8%B0%83%E9%80%9A) and some diffs vs v6.1-rc

Haven't had the time to try it yet but it compiles fine and should work.