### PR TITLE
switch to thumb2 code (-mthumb)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DEFINES := -DLOG_LEVEL=$(LOG_LEVEL) -DBUILD_REVISION=$(shell cat .build_revision
 include	arch/arch.mk
 include	lib/fatfs/fatfs.mk
 
-CFLAGS += -mcpu=cortex-a7 -mthumb-interwork -mno-unaligned-access -mfpu=neon-vfpv4 -mfloat-abi=hard
+CFLAGS += -mcpu=cortex-a7 -mthumb-interwork -mthumb -mno-unaligned-access -mfpu=neon-vfpv4 -mfloat-abi=hard
 CFLAGS += -ffast-math -Os -std=gnu99 -Wall -g $(INCLUDES) $(DEFINES)
 
 ASFLAGS += $(CFLAGS)


### PR DESCRIPTION
This reduces code size by a lot.
LOG_INFO: 39 -> 31KB
LOG_DEBUG: 42 -> 34KB