### PR TITLE
Fix warning implicit declaration of function sunxi_dram_init

### DIFF
--- a/arch/arm32/mach-t113s3/dram.h
+++ b/arch/arm32/mach-t113s3/dram.h
@@ -71,5 +71,6 @@ typedef struct __DRAM_PARA {
 } dram_para_t;
 
 int init_DRAM(int type, dram_para_t *para);
+unsigned long sunxi_dram_init(void);
 
 #endif

--- a/arch/arm32/mach-t113s4/dram.h
+++ b/arch/arm32/mach-t113s4/dram.h
@@ -71,5 +71,6 @@ typedef struct __DRAM_PARA {
 } dram_para_t;
 
 int init_DRAM(int type, dram_para_t *para);
+unsigned long sunxi_dram_init(void);
 
 #endif

--- a/arch/arm32/mach-v851s/dram.h
+++ b/arch/arm32/mach-v851s/dram.h
@@ -71,5 +71,6 @@ typedef struct __DRAM_PARA {
 } dram_para_t;
 
 int init_DRAM(int type, dram_para_t *para);
+unsigned long sunxi_dram_init(void);
 
 #endif


### PR DESCRIPTION
Remove gcc warning:
```
main.c: In function 'main':
main.c:199:2: warning: implicit declaration of function 'sunxi_dram_init'; did you mean 'sunxi_usart_init'? [-Wimplicit-function-declaration]
  199 |  sunxi_dram_init();
      |  ^~~~~~~~~~~~~~~
      |  sunxi_usart_init
```
