### PR TITLE
add printf format checking to message(), fix warnings, add -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ include	arch/arch.mk
 include	lib/fatfs/fatfs.mk
 
 CFLAGS += -mcpu=cortex-a7 -mthumb-interwork -mthumb -mno-unaligned-access -mfpu=neon-vfpv4 -mfloat-abi=hard
-CFLAGS += -ffast-math -Os -std=gnu99 -Wall -g $(INCLUDES) $(DEFINES)
+CFLAGS += -ffast-math -Os -std=gnu99 -Wall -Werror -Wno-unused-function -g $(INCLUDES) $(DEFINES)
 
 ASFLAGS += $(CFLAGS)
 

--- a/arch/arm32/mach-t113s3/dram.c
+++ b/arch/arm32/mach-t113s3/dram.c
@@ -702,8 +702,8 @@ static void mctl_phy_ac_remapping(dram_para_t *para)
 	fuse = (readl(SUNXI_SID_BASE + 0x28) & 0xf00) >> 8;
 	chipid = (readl(SUNXI_SID_BASE) & 0xffff);
 
-	debug("DDR efuse: 0x%x\r\n", fuse);
-	debug("chip id efuse: 0x%x\r\n", chipid);
+	debug("DDR efuse: 0x%" PRIx32 "\r\n", fuse);
+	debug("chip id efuse: 0x%" PRIx32 "\r\n", chipid);
 
 	if (para->dram_type == SUNXI_DRAM_TYPE_DDR2) {
 		if (fuse == 15)
@@ -1000,8 +1000,8 @@ static int dqs_gate_detect(dram_para_t *para)
 	if ((para->dram_tpr13 & BIT(29)) == 0)
 		return 0;
 
-	debug("DX0 state: %d\r\n", dx0);
-	debug("DX1 state: %d\r\n", dx1);
+	debug("DX0 state: %" PRIu32 "\r\n", dx0);
+	debug("DX1 state: %" PRIu32 "\r\n", dx1);
 
 	return 0;
 }
@@ -1142,7 +1142,7 @@ static int auto_scan_dram_size(dram_para_t *para)
 			i = 16;
 		addr_line += i;
 
-		debug("rank %d row = %d \r\n", current_rank, i);
+		debug("rank %" PRIu32 " row = %" PRIu32 " \r\n", current_rank, i);
 
 		/* Store rows in para 1 */
 		para->dram_para1 &= ~(0xffU << (16 * current_rank + 4));
@@ -1174,7 +1174,7 @@ static int auto_scan_dram_size(dram_para_t *para)
 		}
 
 		addr_line += i + 2;
-		debug("rank %d bank = %d \r\n", current_rank, (4 + i * 4));
+		debug("rank %" PRIu32 " bank = %" PRIu32 " \r\n", current_rank, (4 + i * 4));
 
 		/* Store bank in para 1 */
 		para->dram_para1 &= ~(0xfU << (16 * current_rank + 12));
@@ -1220,7 +1220,7 @@ static int auto_scan_dram_size(dram_para_t *para)
 			i = (0x1U << (i - 10));
 		}
 
-		debug("rank %d page size = %d KB \r\n", current_rank, i);
+		debug("rank %" PRIu32 " page size = %" PRIu32 " KB \r\n", current_rank, i);
 
 		/* Store page in para 1 */
 		para->dram_para1 &= ~(0xfU << (16 * current_rank));
@@ -1322,7 +1322,7 @@ int init_DRAM(int type, dram_para_t *para)
 		udelay(10);
 		setbits_le32((SYS_CONTROL_REG_BASE + ZQ_CAL_CTRL_REG), (1 << 0));
 		udelay(20);
-		debug("ZQ value = 0x%x\r\n", readl((SYS_CONTROL_REG_BASE + ZQ_RES_STATUS_REG)));
+		debug("ZQ value = 0x%" PRIx32 "\r\n", readl((SYS_CONTROL_REG_BASE + ZQ_RES_STATUS_REG)));
 	}
 
 	dram_voltage_set(para);
@@ -1340,7 +1340,7 @@ int init_DRAM(int type, dram_para_t *para)
 	if ((rc & 0x44) == 0)
 		debug("DRAM ODT off\r\n");
 	else
-		debug("DRAM ODT value: 0x%x\r\n", rc);
+		debug("DRAM ODT value: 0x%" PRIx32 "\r\n", rc);
 
 	/* Init core, final run */
 	if (mctl_core_init(para) == 0) {
@@ -1357,7 +1357,7 @@ int init_DRAM(int type, dram_para_t *para)
 		rc = (rc >> 16) & ~(1 << 15);
 	} else {
 		rc = DRAMC_get_dram_size();
-		debug("DRAM: size = %dMB\r\n", rc);
+		debug("DRAM: size = %" PRIu32 "MB\r\n", rc);
 		para->dram_para2 = (para->dram_para2 & 0xffffU) | rc << 16;
 	}
 	mem_size_mb = rc;

--- a/arch/arm32/mach-t113s3/sdmmc.c
+++ b/arch/arm32/mach-t113s3/sdmmc.c
@@ -284,7 +284,7 @@ static bool mmc_send_op_cond(sdhci_t *hci, sdmmc_t *card)
 		}
 		udelay(5000);
 	} while (!(cmd.response[0] & OCR_BUSY) && retries--);
-	trace("SHMC: op_cond 0x%x\r\n", cmd.response[0]);
+	trace("SHMC: op_cond 0x%" PRIx32 "\r\n", cmd.response[0]);
 
 	if (retries <= 0)
 		return FALSE;
@@ -554,7 +554,7 @@ static bool sdmmc_detect(sdhci_t *hci, sdmmc_t *card)
 					return FALSE;
 			} while (status != MMC_STATUS_TRAN);
 		}
-		const char *strver = "unknown";
+		const char UNUSED_DEBUG *strver = "unknown";
 		switch (card->extcsd[EXT_CSD_REV]) {
 			case 1:
 				card->version = MMC_VERSION_4_1;

--- a/arch/arm32/mach-t113s3/sunxi_clk.c
+++ b/arch/arm32/mach-t113s3/sunxi_clk.c
@@ -200,9 +200,11 @@ uint32_t sunxi_clk_get_peri1x_rate()
 void sunxi_clk_dump()
 {
 	uint32_t	reg32;
-	uint32_t	cpu_clk_src, plln, pllm;
-	uint8_t		p0, p1;
-	const char *clock_str;
+	uint32_t	cpu_clk_src;
+	uint32_t UNUSED_DEBUG	plln, pllm;
+	uint8_t		p0;
+	uint8_t	UNUSED_DEBUG	p1;
+	const char * UNUSED_DEBUG clock_str;
 
 	/* PLL CPU */
 	reg32		= read32(T113_CCU_BASE + CCU_CPU_AXI_CFG_REG);

--- a/arch/arm32/mach-t113s3/sunxi_clk.c
+++ b/arch/arm32/mach-t113s3/sunxi_clk.c
@@ -253,7 +253,7 @@ void sunxi_clk_dump()
 		p1 = 1;
 	}
 
-	debug("CLK: CPU PLL=%s FREQ=%uMHz\r\n", clock_str, ((((reg32 >> 8) & 0xff) + 1) * 24 / p1));
+	debug("CLK: CPU PLL=%s FREQ=%" PRIu32 "MHz\r\n", clock_str, ((((reg32 >> 8) & 0xff) + 1) * 24 / p1));
 
 	/* PLL PERIx */
 	reg32 = read32(T113_CCU_BASE + CCU_PLL_PERI0_CTRL_REG);
@@ -263,7 +263,7 @@ void sunxi_clk_dump()
 		p0	 = ((reg32 >> 16) & 0x03) + 1;
 		p1	 = ((reg32 >> 20) & 0x03) + 1;
 
-		debug("CLK: PLL_peri (2X)=%uMHz, (1X)=%uMHz, (800M)=%uMHz\r\n", (24 * plln) / (pllm * p0),
+		debug("CLK: PLL_peri (2X)=%" PRIu32 "MHz, (1X)=%" PRIu32 "MHz, (800M)=%" PRIu32 "MHz\r\n", (24 * plln) / (pllm * p0),
 			  (24 * plln) / (pllm * p0) >> 1, (24 * plln) / (pllm * p1));
 	} else {
 		debug("CLK: PLL_peri disabled\r\n");
@@ -278,7 +278,7 @@ void sunxi_clk_dump()
 		p1	 = ((reg32 >> 1) & 0x1) + 1;
 		p0	 = (reg32 & 0x01) + 1;
 
-		debug("CLK: PLL_ddr=%uMHz\r\n", (24 * plln) / (p0 * p1));
+		debug("CLK: PLL_ddr=%" PRIu32 "MHz\r\n", (24 * plln) / (p0 * p1));
 
 	} else {
 		debug("CLK: PLL_ddr disabled\r\n");

--- a/arch/arm32/mach-t113s3/sunxi_dma.c
+++ b/arch/arm32/mach-t113s3/sunxi_dma.c
@@ -234,7 +234,7 @@ int dma_test()
 	u32		  i, valid;
 
 	len = ALIGN(len, 4);
-	trace("DMA: test 0x%08x ====> 0x%08x, len %uKB \r\n", (u32)src_addr, (u32)dst_addr, (len / 1024));
+	trace("DMA: test 0x%08" PRIx32 " ====> 0x%08" PRIx32 ", len %" PRIu32 "KB \r\n", (u32)src_addr, (u32)dst_addr, (len / 1024));
 
 	/* dma */
 	dma_set.loop_mode		= 0;
@@ -297,7 +297,7 @@ int dma_test()
 		if (valid) {
 			debug("DMA: test OK in %lums\r\n", (time_ms() - timeout));
 		} else
-			error("DMA: test check failed at %u bytes\r\n", i);
+			error("DMA: test check failed at %" PRIu32 " bytes\r\n", i);
 	}
 
 	dma_stop(hdma);

--- a/arch/arm32/mach-t113s3/sunxi_sdhci.c
+++ b/arch/arm32/mach-t113s3/sunxi_sdhci.c
@@ -247,7 +247,7 @@ static void set_read_timeout(sdhci_t *sdhci, u32 timeout)
 	rval |= (rdto_clk << 8);
 	sdhci->reg->timeout = rval;
 
-	trace("rdtoclk:%u, reg-tmout:%u, gctl:%x, clock:%u, nstr:%x\n", rdto_clk, sdhci->reg->timeout, sdhci->reg->gctrl,
+	trace("rdtoclk:%" PRIu32 ", reg-tmout:%" PRIu32 ", gctl:%" PRIx32 ", clock:%u, nstr:%" PRIx32 "\n", rdto_clk, sdhci->reg->timeout, sdhci->reg->gctrl,
 		  sdhci->clock, sdhci->reg->ntsr);
 }
 
@@ -289,8 +289,8 @@ static int prepare_dma(sdhci_t *sdhci, sdhci_data_t *data)
 		} else {
 			pdes[des_idx].next_desc_addr = ((u32)&pdes[des_idx + 1]) >> 2;
 		}
-		trace("SMHC: frag %d, remain %d, des[%d] = 0x%08x:\r\n"
-			  "  [0] = 0x%08x, [1] = 0x%08x, [2] = 0x%08x, [3] = 0x%08x\r\n",
+		trace("SMHC: frag %" PRIu32 ", remain %" PRIu32 ", des[%" PRIu32 "] = 0x%08" PRIx32 ":\r\n"
+			  "  [0] = 0x%08" PRIx32 ", [1] = 0x%08" PRIx32 ", [2] = 0x%08" PRIx32 ", [3] = 0x%08" PRIx32 "\r\n",
 			  i, remain, des_idx, (u32)(&pdes[des_idx]), (u32)((u32 *)&pdes[des_idx])[0],
 			  (u32)((u32 *)&pdes[des_idx])[1], (u32)((u32 *)&pdes[des_idx])[2], (u32)((u32 *)&pdes[des_idx])[3]);
 	}
@@ -335,15 +335,15 @@ static int wait_done(sdhci_t *sdhci, sdhci_data_t *dat, u32 timeout_msecs, u32 f
 	u32 status;
 	u32 done  = 0;
 	u32 start = time_ms();
-	trace("SMHC: wait for flag 0x%x\r\n", flag);
+	trace("SMHC: wait for flag 0x%" PRIx32 "\r\n", flag);
 	do {
 		status = sdhci->reg->rint;
 		if ((time_ms() > (start + timeout_msecs))) {
-			warning("SMHC: wait timeout %x status %x flag %x\r\n", status & SMHC_RINT_INTERRUPT_ERROR_BIT, status,
+			warning("SMHC: wait timeout %" PRIx32 " status %" PRIx32 " flag %" PRIx32 "\r\n", status & SMHC_RINT_INTERRUPT_ERROR_BIT, status,
 					flag);
 			return -1;
 		} else if ((status & SMHC_RINT_INTERRUPT_ERROR_BIT)) {
-			warning("SMHC: error 0x%x status 0x%x\r\n", status & SMHC_RINT_INTERRUPT_ERROR_BIT,
+			warning("SMHC: error 0x%" PRIx32 " status 0x%" PRIx32 "\r\n", status & SMHC_RINT_INTERRUPT_ERROR_BIT,
 					status & ~SMHC_RINT_INTERRUPT_ERROR_BIT);
 			return -1;
 		}
@@ -367,12 +367,12 @@ static bool read_bytes(sdhci_t *sdhci, sdhci_data_t *dat)
 	if (timeout < 250)
 		timeout = 250;
 
-	trace("SMHC: read %u\r\n", count);
+	trace("SMHC: read %" PRIu32 "\r\n", count);
 
 	status = sdhci->reg->status;
 	err	   = sdhci->reg->rint & SMHC_RINT_INTERRUPT_ERROR_BIT;
 	if (err)
-		warning("SMHC: interrupt error 0x%x status 0x%x\r\n", err & SMHC_RINT_INTERRUPT_ERROR_BIT, status);
+		warning("SMHC: interrupt error 0x%" PRIx32 " status 0x%" PRIx32 "\r\n", err & SMHC_RINT_INTERRUPT_ERROR_BIT, status);
 
 	while ((!err) && (count >= sizeof(sdhci->reg->fifo))) {
 		while (sdhci->reg->status & SMHC_STATUS_FIFO_EMPTY) {
@@ -403,12 +403,12 @@ static bool read_bytes(sdhci_t *sdhci, sdhci_data_t *dat)
 	} while (!done && !err);
 
 	if (err & SMHC_RINT_INTERRUPT_ERROR_BIT) {
-		warning("SMHC: interrupt error 0x%x status 0x%x\r\n", err & SMHC_RINT_INTERRUPT_ERROR_BIT, status);
+		warning("SMHC: interrupt error 0x%" PRIx32 " status 0x%" PRIx32 "\r\n", err & SMHC_RINT_INTERRUPT_ERROR_BIT, status);
 		return FALSE;
 	}
 
 	if (count) {
-		warning("SMHC: read %u leftover\r\n", count);
+		warning("SMHC: read %" PRIu32 " leftover\r\n", count);
 		return FALSE;
 	}
 	return TRUE;
@@ -424,7 +424,7 @@ static bool write_bytes(sdhci_t *sdhci, sdhci_data_t *dat)
 	if (timeout < 250)
 		timeout = 250;
 
-	trace("SMHC: write %u\r\n", count);
+	trace("SMHC: write %llu\r\n", count);
 
 	status = sdhci->reg->status;
 	err	   = sdhci->reg->rint & SMHC_RINT_INTERRUPT_ERROR_BIT;
@@ -466,7 +466,7 @@ bool sdhci_transfer(sdhci_t *sdhci, sdhci_cmd_t *cmd, sdhci_data_t *dat)
 	u32	 timeout;
 	bool dma = false;
 
-	trace("SMHC: CMD%u 0x%x dlen:%u\r\n", cmd->idx, cmd->arg, dat ? dat->blkcnt * dat->blksz : 0);
+	trace("SMHC: CMD%" PRIu32 " 0x%" PRIx32 " dlen:%" PRIu32 "\r\n", cmd->idx, cmd->arg, dat ? dat->blkcnt * dat->blksz : 0);
 
 	if (cmd->idx == MMC_STOP_TRANSMISSION) {
 		timeout = time_ms();
@@ -580,7 +580,7 @@ bool sdhci_reset(sdhci_t *sdhci)
 
 bool sdhci_set_width(sdhci_t *sdhci, u32 width)
 {
-	const char *mode = "1 bit";
+	const char UNUSED_TRACE *mode = "1 bit";
 	sdhci->reg->gctrl &= ~SMHC_GCTRL_DDR_MODE;
 	switch (width) {
 		case MMC_BUS_WIDTH_1:
@@ -591,7 +591,7 @@ bool sdhci_set_width(sdhci_t *sdhci, u32 width)
 			mode			  = "4 bit";
 			break;
 		default:
-			error("SMHC: %u width value invalid\r\n", width);
+			error("SMHC: %" PRIu32 " width value invalid\r\n", width);
 			return FALSE;
 	}
 	if (sdhci->clock == MMC_CLK_50M_DDR) {
@@ -721,11 +721,11 @@ bool sdhci_set_clock(sdhci_t *sdhci, smhc_clk_t clock)
 	}
 
 	if (n > 3) {
-		error("mmc %u error cannot set clock to %uHz\n", sdhci->name, hz);
+		error("mmc %s error cannot set clock to %" PRIu32 "Hz\n", sdhci->name, hz);
 		return false;
 	}
 
-	trace("SMHC: clock ratio %u\r\n", div);
+	trace("SMHC: clock ratio %" PRIu32 "\r\n", div);
 
 	sdhci->reg->clkcr &= ~SMHC_CLKCR_CARD_CLOCK_ON; // Disable clock
 	if (!update_card_clock(sdhci))

--- a/arch/arm32/mach-t113s3/sunxi_spi.c
+++ b/arch/arm32/mach-t113s3/sunxi_spi.c
@@ -230,8 +230,8 @@ static uint32_t spi_set_clk(sunxi_spi_t *spi, u32 spi_clk, u32 mclk, u32 cdr2)
 		}
 	}
 
-	trace("SPI: clock div=%u \r\n", div);
-	debug("SPI: set clock asked=%dMHz actual=%dMHz mclk=%dMHz\r\n", spi_clk / 1000000, freq / 1000000, mclk / 1000000);
+	trace("SPI: clock div=%" PRIu32 " \r\n", div);
+	debug("SPI: set clock asked=%" PRIu32 "MHz actual=%" PRIu32 "MHz mclk=%" PRIu32 "MHz\r\n", spi_clk / 1000000, freq / 1000000, mclk / 1000000);
 
 	write32(spi->base + SPI_CCR, reg);
 
@@ -290,7 +290,7 @@ static int spi_clk_init(uint32_t mod_clk)
 
 	factor_m = m - 1;
 	rval	 = (1U << 31) | (0x1 << 24) | (n << 8) | factor_m;
-	trace("SPI: parent_clk=%dMHz, div=%d, n=%d, m=%d\r\n", source_clk / 1000 / 1000, divi, n + 1, m);
+	trace("SPI: parent_clk=%" PRIu32 "MHz, div=%" PRIu32 ", n=%" PRIu32 ", m=%" PRIu32 "\r\n", source_clk / 1000 / 1000, divi, n + 1, m);
 	write32(T113_CCU_BASE + CCU_SPI0_CLK_REG, rval);
 
 	return 0;
@@ -525,7 +525,7 @@ static void spi_set_io_mode(sunxi_spi_t *spi, spi_io_mode_t mode)
 static int spi_transfer(sunxi_spi_t *spi, spi_io_mode_t mode, void *txbuf, uint32_t txlen, void *rxbuf, uint32_t rxlen)
 {
 	uint32_t stxlen, fcr;
-	trace("SPI: tsfr mode=%u tx=%u rx=%u\r\n", mode, txlen, rxlen);
+	trace("SPI: tsfr mode=%u tx=%" PRIu32 " rx=%" PRIu32 "\r\n", mode, txlen, rxlen);
 
 	spi_set_io_mode(spi, mode);
 
@@ -574,7 +574,7 @@ static int spi_transfer(sunxi_spi_t *spi, spi_io_mode_t mode, void *txbuf, uint3
 		}
 	}
 
-	trace("SPI: ISR=0x%x\r\n", read32(spi->base + SPI_ISR));
+	trace("SPI: ISR=0x%" PRIx32 "\r\n", read32(spi->base + SPI_ISR));
 
 	return txlen + rxlen;
 }

--- a/include/types.h
+++ b/include/types.h
@@ -2,6 +2,8 @@
 #ifndef __ASM_ARM_TYPES_H
 #define __ASM_ARM_TYPES_H
 
+#include <stdint.h>
+
 typedef unsigned short umode_t;
 
 /*
@@ -34,8 +36,9 @@ typedef unsigned char u8;
 typedef signed short   s16;
 typedef unsigned short u16;
 
-typedef signed int	 s32;
-typedef unsigned int u32;
+/* dont mix stdint and basic types, uint32_t and u32 are intermixed throughout code */
+typedef int32_t s32;
+typedef uint32_t u32;
 
 typedef signed long long   s64;
 typedef unsigned long long u64;

--- a/lib/debug.h
+++ b/lib/debug.h
@@ -11,32 +11,42 @@
 
 #if LOG_LEVEL >= LOG_TRACE
 #define trace(fmt, ...) message("[T] " fmt, ##__VA_ARGS__)
+#define UNUSED_TRACE
 #else
 #define trace(...)
+#define UNUSED_TRACE __attribute__((__unused__))
 #endif
 
 #if LOG_LEVEL >= LOG_DEBUG
 #define debug(fmt, ...) message("[D] " fmt, ##__VA_ARGS__)
+#define UNUSED_DEBUG
 #else
 #define debug(...)
+#define UNUSED_DEBUG __attribute__((__unused__))
 #endif
 
 #if LOG_LEVEL >= LOG_INFO
 #define info(fmt, ...) message("[I] " fmt, ##__VA_ARGS__)
+#define UNUSED_INFO
 #else
 #define info(...)
+#define UNUSED_INFO __attribute__((__unused__))
 #endif
 
 #if LOG_LEVEL >= LOG_WARNING
 #define warning(fmt, ...) message("[W] " fmt, ##__VA_ARGS__)
+#define UNUSED_WARNING
 #else
 #define warning(...)
+#define UNUSED_WARNING __attribute__((__unused__))
 #endif
 
 #if LOG_LEVEL >= LOG_ERROR
 #define error(fmt, ...) message("[E] " fmt, ##__VA_ARGS__)
+#define UNUSED_ERROR
 #else
 #define error(...)
+#define UNUSED_ERROR __attribute__((__unused__))
 #endif
 
 #define fatal(fmt, ...)                                         \
@@ -46,6 +56,6 @@
 		reset();                                                \
 	}
 
-void message(const char *fmt, ...);
+void __attribute__((format(printf, 1, 2))) message(const char *fmt, ...);
 
 #endif

--- a/lib/fatfs/diskio.c
+++ b/lib/fatfs/diskio.c
@@ -76,7 +76,7 @@ DRESULT disk_read(BYTE	pdrv, /* Physical drive nmuber to identify the drive */
 	last  = sector + count;
 	bytes = count * FF_MIN_SS;
 
-	trace("FATFS: read %u sectors at %u\r\n", count, first);
+	trace("FATFS: read %u sectors at %" PRIu32 "\r\n", count, first);
 
 #ifdef CONFIG_FATFS_CACHE_SIZE
 	// Read starts in cache but overflows
@@ -85,12 +85,12 @@ DRESULT disk_read(BYTE	pdrv, /* Physical drive nmuber to identify the drive */
 		memcpy(buff, cache + (first - cache_first) * FF_MIN_SS, chunk);
 		buff += chunk;
 		first += (cache_last - first);
-		trace("FATFS: chunk %u first %u\r\n", chunk, first);
+		trace("FATFS: chunk %" PRIu32 " first %" PRIu32 "\r\n", chunk, first);
 	}
 
 	// Read is NOT in the cache
 	if (last > cache_last || first < cache_first) {
-		trace("FATFS: if %u > %u || %u < %u\r\n", last, cache_last, first, cache_first);
+		trace("FATFS: if %" PRIu32 " > %" PRIu32 " || %" PRIu32 " < %" PRIu32 "\r\n", last, cache_last, first, cache_first);
 
 		read_pos	= (first / cache_size) * cache_size; // TODO: check with card max capacity
 		cache_first = read_pos;
@@ -98,15 +98,15 @@ DRESULT disk_read(BYTE	pdrv, /* Physical drive nmuber to identify the drive */
 		blkread		= sdmmc_blk_read(&card0, cache, read_pos, cache_size);
 
 		if (blkread != cache_size) {
-			warning("FATFS: MMC read %u/%u blocks\r\n", blkread, cache_size);
+			warning("FATFS: MMC read %" PRIu32 "/%" PRIu32 " blocks\r\n", blkread, cache_size);
 			return RES_ERROR;
 		}
-		trace("FATFS: cached %u sectors (%uKB) at %u/[%u-%u]\r\n", blkread, (blkread * FF_MIN_SS) / 1024, first,
+		trace("FATFS: cached %" PRIu32 " sectors (%" PRIu32 "KB) at %" PRIu32 "/[%" PRIu32 "-%" PRIu32 "]\r\n", blkread, (blkread * FF_MIN_SS) / 1024, first,
 			  read_pos, read_pos + cache_size);
 	}
 
 	// Copy from read cache to output buffer
-	trace("FATFS: copy %u from 0x%x to 0x%x\r\n", bytes, (cache + ((first - cache_first) * FF_MIN_SS)), buff);
+	trace("FATFS: copy %" PRIu32 " from 0x%p to 0x%p\r\n", bytes, (cache + ((first - cache_first) * FF_MIN_SS)), buff);
 	memcpy(buff, (cache + ((first - cache_first) * FF_MIN_SS)), bytes);
 
 	return RES_OK;

--- a/main.c
+++ b/main.c
@@ -245,7 +245,9 @@ int main(void)
 #endif
 
 #ifdef CONFIG_BOOT_SPINAND
+#if defined(CONFIG_BOOT_SDCARD) || defined(CONFIG_BOOT_MMC)
 _spi:
+#endif
 	dma_init();
 	dma_test();
 	debug("SPI: init\r\n");
@@ -262,7 +264,9 @@ _spi:
 
 #endif // CONFIG_SPI_NAND
 
+#if defined(CONFIG_BOOT_SDCARD) || defined(CONFIG_BOOT_MMC)
 _boot:
+#endif
 	if (boot_image_setup((unsigned char *)image.dest, &entry_point)) {
 		fatal("boot setup failed\r\n");
 	}

--- a/main.c
+++ b/main.c
@@ -57,7 +57,7 @@ static int fatfs_loadimage(char *filename, BYTE *dest)
 	UINT	 total_read = 0;
 	FRESULT	 fret;
 	int		 ret;
-	uint32_t start, time;
+	uint32_t UNUSED_DEBUG start, time;
 
 	fret = f_open(&file, filename, FA_OPEN_EXISTING | FA_READ);
 	if (fret != FR_OK) {
@@ -87,7 +87,7 @@ static int fatfs_loadimage(char *filename, BYTE *dest)
 read_fail:
 	fret = f_close(&file);
 
-	debug("FATFS: read in %ums at %.2fMB/S\r\n", time, (f32)(total_read / time) / 1024.0f);
+	debug("FATFS: read in %" PRIu32 "ms at %.2fMB/S\r\n", time, (f32)(total_read / time) / 1024.0f);
 
 open_fail:
 	return ret;
@@ -98,14 +98,14 @@ static int load_sdcard(image_info_t *image)
 	FATFS	fs;
 	FRESULT fret;
 	int		ret;
-	u32		start;
+	u32 UNUSED_DEBUG	start;
 
 #if defined(CONFIG_SDMMC_SPEED_TEST_SIZE) && LOG_LEVEL >= LOG_DEBUG
 	u32 test_time;
 	start = time_ms();
 	sdmmc_blk_read(&card0, (u8 *)(SDRAM_BASE), 0, CONFIG_SDMMC_SPEED_TEST_SIZE);
 	test_time = time_ms() - start;
-	debug("SDMMC: speedtest %uKB in %ums at %uKB/S\r\n", (CONFIG_SDMMC_SPEED_TEST_SIZE * 512) / 1024, test_time,
+	debug("SDMMC: speedtest %uKB in %" PRIu32 "ms at %" PRIu32 "KB/S\r\n", (CONFIG_SDMMC_SPEED_TEST_SIZE * 512) / 1024, test_time,
 		  (CONFIG_SDMMC_SPEED_TEST_SIZE * 512) / test_time);
 #endif // SDMMC_SPEED_TEST
 
@@ -137,7 +137,7 @@ static int load_sdcard(image_info_t *image)
 	} else {
 		debug("FATFS: unmount OK\r\n");
 	}
-	debug("FATFS: done in %ums\r\n", time_ms() - start);
+	debug("FATFS: done in %" PRIu32 "ms\r\n", time_ms() - start);
 
 	return 0;
 }
@@ -149,7 +149,7 @@ int load_spi_nand(sunxi_spi_t *spi, image_info_t *image)
 {
 	linux_zimage_header_t *hdr;
 	unsigned int		   size;
-	uint64_t			   start, time;
+	uint64_t UNUSED_DEBUG	   start, time;
 
 	if (spi_nand_detect(spi) != 0)
 		return -1;
@@ -194,7 +194,7 @@ int main(void)
 	sunxi_clk_init();
 
 	message("\r\n");
-	info("AWBoot r%u starting...\r\n", (u32)BUILD_REVISION);
+	info("AWBoot r%" PRIu32 " starting...\r\n", (u32)BUILD_REVISION);
 
 	sunxi_dram_init();
 
@@ -218,7 +218,7 @@ int main(void)
 	if (sunxi_sdhci_init(&sdhci0) != 0) {
 		fatal("SMHC: %s controller init failed\r\n", sdhci0.name);
 	} else {
-		info("SMHC: %s controller v%x initialized\r\n", sdhci0.name, sdhci0.reg->vers);
+		info("SMHC: %s controller v%" PRIx32 " initialized\r\n", sdhci0.name, sdhci0.reg->vers);
 	}
 	if (sdmmc_init(&card0, &sdhci0) != 0) {
 #ifdef CONFIG_BOOT_SPINAND


### PR DESCRIPTION
This change adds format checking to `message()` so the compiler will warn on incorrect `printf()` strings.

Once on, there were considerable signness and size errors, plus a few just plain incorrect formats.  Switched most printf's to `PRIu32` and similar from inttypes.h to make code portable/consistant.

Also fixed other warnings such as unused variables (especially around optimizing out `debug()` for example)

There is considerable intermixing of `u32` and `uint32_t` throughout the code and these are actually different, `u32` was an `unsigned int`, and `uint32_t` was a `long unsigned int`.  Both being 32bit but for consistancy fixing this makes sense.

