### PR TITLE
Add support for booting from 4KB page size SPI NAND devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,11 @@ tools:
 
 mkboot: build tools
 	cp $(TARGET)-boot.bin $(TARGET)-boot-spi.bin
+	cp $(TARGET)-boot.bin $(TARGET)-boot-spi-4k.bin
 	cp $(TARGET)-boot.bin $(TARGET)-boot-sd.bin
 	tools/mksunxi $(TARGET)-fel.bin 8192
 	tools/mksunxi $(TARGET)-boot-spi.bin 8192
+	tools/mksunxi $(TARGET)-boot-spi-4k.bin 8192 4096
 	tools/mksunxi $(TARGET)-boot-sd.bin 512
 
 spi-boot.img: mkboot


### PR DESCRIPTION
The T113-s3 BROM doesn't support 4KB page size SPI NAND Flashes.  It assumes all SPI NAND Flashes are 2KB page size and only reads the first 2KB of each page.  It doesn't perform a `READ ID` command or similar, just goes ahead and reads pages assuming a 2KB size.

Using a logic analizer I was able to confirm this.  BROM did the following SPI NAND commands out of reset.  Each read is 2KB in size which resulted in a corrupt image in SRAM as it was missing 50% of the data:

```
reset
wait 800us
read page 0 0 1 2 3 4 5 6 7 8 9 a b c d e f 10 11 12 13
wait 1ms
read page 0
reset
wait 800us
read page 40 80 c0 100 140 180 1c0 40 80 c0 100 140 180 1c0 ... 
```

The included PR fixes this by adding an option to `mksunxi` to place only 2KB of data in each flash page spacing them out if needed.  A `awboot-boot-spi-4k.bin` is created during the build process.

I've confirmed that BROM loads `awboot-boot-spi-4k.bin` succesfully from a Micron MT29F4G01ABAFDWB (512MB, 4KB page, 256KB block) flash, passes csum, and starts executing awboot from SRAM.