### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 
+*.d
 *.o
 *.bin
 *.elf
 *.map
 *.lfs
 
-build/*
+build-*/*
 
 tools/mksunxi
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ LOG_LEVEL ?= 30
 SRCS := main.c board.c lib/debug.c lib/xformat.c lib/fdt.c lib/string.c
 
 INCLUDE_DIRS :=-I . -I include -I lib
-LIB_DIR := -L ./
 LIBS := -lgcc -nostdlib
 DEFINES := -DLOG_LEVEL=$(LOG_LEVEL) -DBUILD_REVISION=$(shell cat .build_revision)
 
@@ -16,7 +15,7 @@ include	arch/arch.mk
 include	lib/fatfs/fatfs.mk
 
 CFLAGS += -mcpu=cortex-a7 -mthumb-interwork -mthumb -mno-unaligned-access -mfpu=neon-vfpv4 -mfloat-abi=hard
-CFLAGS += -ffast-math -ffunction-sections -fdata-sections -Os -std=gnu99 -Wall -Werror -Wno-unused-function -g $(INCLUDES) $(DEFINES)
+CFLAGS += -ffast-math -ffunction-sections -fdata-sections -Os -std=gnu99 -Wall -Werror -Wno-unused-function -g -MMD $(INCLUDES) $(DEFINES)
 
 ASFLAGS += $(CFLAGS)
 
@@ -30,18 +29,7 @@ OBJCOPY=$(CROSS_COMPILE)-objcopy
 HOSTCC=gcc
 HOSTSTRIP=strip
 
-DATE=/bin/date
-CAT=/bin/cat
-ECHO=/bin/echo
-WORKDIR=$(/bin/pwd)
 MAKE=make
-
-# Objects
-EXT_OBJS =
-OBJ_DIR = build
-BUILD_OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.o)
-BUILD_OBJSA = $(ASRCS:%.S=$(OBJ_DIR)/%.o)
-OBJS = $(BUILD_OBJSA) $(BUILD_OBJS) $(EXT_OBJS)
 
 DTB ?= sun8i-t113-mangopi-dual.dtb
 KERNEL ?= zImage
@@ -54,55 +42,85 @@ begin:
 	@$(CC) -v 2>&1 | tail -1
 
 build_revision:
-	@/bin/expr `cat .build_revision` + 1 > .build_revision
+	@expr `cat .build_revision` + 1 > .build_revision
 
-.PHONY: tools boot.img
+.PHONY: tools git begin build mkboot clean format
 .SILENT:
 
 git:
 	cp -f tools/hooks/* .git/hooks/
 
-build: build_revision $(TARGET)-boot.elf $(TARGET)-boot.bin $(TARGET)-fel.elf $(TARGET)-fel.bin
+build:: build_revision
 
-.SECONDARY : $(TARGET)
-.PRECIOUS : $(OBJS)
-$(TARGET)-fel.elf: $(OBJS)
-	echo "  LD    $@"
-	$(CC) -E -P -x c -D__RAM_BASE=0x00030000 ./arch/arm32/mach-t113s3/link.ld > build/link-fel.ld
-	$(CC) $^ -o $@ $(LIB_DIR) -T build/link-fel.ld $(LDFLAGS) -Wl,-Map,$(TARGET)-fel.map
+# $(1): varient name
+# $(2): values to remove from board.h
+define VARIENT =
 
-$(TARGET)-boot.elf: $(OBJS)
-	echo "  LD    $@"
-	$(CC) -E -P -x c -D__RAM_BASE=0x00020000 ./arch/arm32/mach-t113s3/link.ld > build/link-boot.ld
-	$(CC) $^ -o $@ $(LIB_DIR) -T build/link-boot.ld $(LDFLAGS) -Wl,-Map,$(TARGET)-boot.map
+# Objects
+$(1)_OBJ_DIR = build-$(1)
+$(1)_BUILD_OBJS = $$(SRCS:%.c=$$($(1)_OBJ_DIR)/%.o)
+$(1)_BUILD_OBJSA = $$(ASRCS:%.S=$$($(1)_OBJ_DIR)/%.o)
+$(1)_OBJS = $$($(1)_BUILD_OBJSA) $$($(1)_BUILD_OBJS)
 
-$(TARGET)-fel.bin: $(TARGET)-fel.elf
-	@echo OBJCOPY $@
-	$(OBJCOPY) -O binary $< $@
-	$(SIZE) $(TARGET)-fel.elf
+build:: $$($(1)_OBJ_DIR)/$$(TARGET)-boot.elf $$($(1)_OBJ_DIR)/$$(TARGET)-boot.bin $$($(1)_OBJ_DIR)/$$(TARGET)-fel.elf $$($(1)_OBJ_DIR)/$$(TARGET)-fel.bin
 
-$(TARGET)-boot.bin: $(TARGET)-boot.elf
-	@echo OBJCOPY $@
-	$(OBJCOPY) -O binary $< $@
-	$(SIZE) $(TARGET)-boot.elf
+.PRECIOUS : $$($(1)_OBJS)
+$$($(1)_OBJ_DIR)/$$(TARGET)-fel.elf: $$($(1)_OBJS)
+	echo "  LD    $$@"
+	$$(CC) -E -P -x c -D__RAM_BASE=0x00030000 ./arch/arm32/mach-t113s3/link.ld > $$($(1)_OBJ_DIR)/link-fel.ld
+	$$(CC) $$^ -o $$@ -T $$($(1)_OBJ_DIR)/link-fel.ld $$(LDFLAGS) -Wl,-Map,$$($(1)_OBJ_DIR)/$$(TARGET)-fel.map
 
-$(OBJ_DIR)/%.o : %.c
-	echo "  CC    $<"
-	mkdir -p $(@D)
-	$(CC) $(CFLAGS) $(INCLUDE_DIRS) -c $< -o $@
+$$($(1)_OBJ_DIR)/$$(TARGET)-boot.elf: $$($(1)_OBJS)
+	echo "  LD    $$@"
+	$$(CC) -E -P -x c -D__RAM_BASE=0x00020000 ./arch/arm32/mach-t113s3/link.ld > $$($(1)_OBJ_DIR)/link-boot.ld
+	$$(CC) $$^ -o $$@ -T $$($(1)_OBJ_DIR)/link-boot.ld $$(LDFLAGS) -Wl,-Map,$$($(1)_OBJ_DIR)/$$(TARGET)-boot.map
 
-$(OBJ_DIR)/%.o : %.S
-	echo "  CC    $<"
-	mkdir -p $(@D)
-	$(CC) $(ASFLAGS) $(INCLUDE_DIRS) -c $< -o $@
+$$($(1)_OBJ_DIR)/$$(TARGET)-fel.bin: $$($(1)_OBJ_DIR)/$$(TARGET)-fel.elf
+	@echo OBJCOPY $$@
+	$$(OBJCOPY) -O binary $$< $$@
 
-clean:
-	rm -rf $(OBJ_DIR)
-	rm -f $(TARGET)
+$$($(1)_OBJ_DIR)/$$(TARGET)-boot.bin: $$($(1)_OBJ_DIR)/$$(TARGET)-boot.elf
+	@echo OBJCOPY $$@
+	$$(OBJCOPY) -O binary $$< $$@
+
+$$($(1)_OBJ_DIR)/%.o : %.c
+	echo "  CC    $$@"
+	mkdir -p $$(@D)
+	$$(CC) $$(CFLAGS) -include $$($(1)_OBJ_DIR)/board.h $$(INCLUDE_DIRS) -c $$< -o $$@
+
+$$($(1)_OBJ_DIR)/%.o : %.S
+	echo "  CC    $$@"
+	mkdir -p $$(@D)
+	$$(CC) $$(ASFLAGS) $$(INCLUDE_DIRS) -c $$< -o $$@
+
+$$($(1)_OBJS): $$($(1)_OBJ_DIR)/board.h
+
+$$($(1)_OBJ_DIR)/board.h: board.h
+	echo "  GEN   $$@"
+	mkdir -p $$(@D)
+	grep -v "$(2)" >$$@ <$$<
+
+clean::
+	rm -rf $$($(1)_OBJ_DIR)
+
+-include $$(patsubst %.o,%.d,$$($(1)_OBJS))
+
+endef
+
+# build spi-only image without sd/mmc
+$(eval $(call VARIENT,spi,CONFIG_BOOT_SDCARD\|CONFIG_BOOT_MMC))
+
+# build sd/mmc only image without spi
+$(eval $(call VARIENT,sdmmc,CONFIG_BOOT_SPINAND))
+
+# build image with everything
+$(eval $(call VARIENT,all,XXXXXXXXX))
+
+clean::
 	rm -f $(TARGET)-*.bin
 	rm -f $(TARGET)-*.map
-	rm -f $(TARGET)-*.elf
 	rm -f *.img
+	rm -f *.d
 	$(MAKE) -C tools clean
 
 format:
@@ -112,13 +130,24 @@ tools:
 	$(MAKE) -C tools all
 
 mkboot: build tools
-	cp $(TARGET)-boot.bin $(TARGET)-boot-spi.bin
-	cp $(TARGET)-boot.bin $(TARGET)-boot-spi-4k.bin
-	cp $(TARGET)-boot.bin $(TARGET)-boot-sd.bin
-	tools/mksunxi $(TARGET)-fel.bin 8192
+	echo "SPI:"
+	$(SIZE) build-spi/$(TARGET)-boot.elf
+	cp -f build-spi/$(TARGET)-boot.bin $(TARGET)-boot-spi.bin
+	cp -f build-spi/$(TARGET)-boot.bin $(TARGET)-boot-spi-4k.bin
 	tools/mksunxi $(TARGET)-boot-spi.bin 8192
 	tools/mksunxi $(TARGET)-boot-spi-4k.bin 8192 4096
+
+	echo "SDMMC:"
+	$(SIZE) build-sdmmc/$(TARGET)-boot.elf
+	cp -f build-sdmmc/$(TARGET)-boot.bin $(TARGET)-boot-sd.bin
 	tools/mksunxi $(TARGET)-boot-sd.bin 512
+
+	echo "ALL:"
+	$(SIZE) build-all/$(TARGET)-boot.elf
+	cp -f build-all/$(TARGET)-boot.bin $(TARGET)-boot-all.bin
+	cp -f build-all/$(TARGET)-boot.bin $(TARGET)-fel.bin
+	tools/mksunxi $(TARGET)-fel.bin 8192
+	tools/mksunxi $(TARGET)-boot-all.bin 8192
 
 spi-boot.img: mkboot
 	rm -f spi-boot.img

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ include	arch/arch.mk
 include	lib/fatfs/fatfs.mk
 
 CFLAGS += -mcpu=cortex-a7 -mthumb-interwork -mthumb -mno-unaligned-access -mfpu=neon-vfpv4 -mfloat-abi=hard
-CFLAGS += -ffast-math -Os -std=gnu99 -Wall -Werror -Wno-unused-function -g $(INCLUDES) $(DEFINES)
+CFLAGS += -ffast-math -ffunction-sections -fdata-sections -Os -std=gnu99 -Wall -Werror -Wno-unused-function -g $(INCLUDES) $(DEFINES)
 
 ASFLAGS += $(CFLAGS)
 
-LDFLAGS += $(CFLAGS) $(LIBS)
+LDFLAGS += $(CFLAGS) $(LIBS) -Wl,--gc-sections
 
 STRIP=$(CROSS_COMPILE)-strip
 CC=$(CROSS_COMPILE)-gcc

--- a/arch/arm32/mach-t113s3/link.ld
+++ b/arch/arm32/mach-t113s3/link.ld
@@ -43,6 +43,8 @@ MEMORY
 /* The stack size used by the application. NOTE: you need to adjust according to your application. */
 STACK_SIZE = 0x1000; /* 4KB */
 
+ENTRY(reset)
+
 /* Section Definitions */
 SECTIONS
 {

--- a/lib/fatfs/fatfs.mk
+++ b/lib/fatfs/fatfs.mk
@@ -2,12 +2,7 @@ FS_FAT := lib/fatfs
 
 INCLUDE_DIRS += -I $(FS_FAT)
 
-USE_FAT = $(shell grep -E "^\#define CONFIG_BOOT_(SDCARD|MMC)" board.h)
-
-ifneq ($(USE_FAT),)
 SRCS	+=  $(FS_FAT)/ff.c
 SRCS	+=  $(FS_FAT)/diskio.c
 SRCS	+=  $(FS_FAT)/ffsystem.c
 SRCS	+=  $(FS_FAT)/ffunicode.c
-
-endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,5 @@
 
-BUILD_DIR=$(CURDIR)/build
+BUILD_DIR=build
 
 MKSUNXI = mksunxi
 
@@ -17,22 +17,25 @@ CC  ?= gcc
 CXX ?= g++
 
 all: tools
-tools: $(BUILD_DIR) $(MKSUNXI)
+tools: $(MKSUNXI)
 
-$(BUILD_DIR):
-	mkdir -p $(BUILD_DIR)
+.PHONY: all tools clean
+.SILENT:
 
 clean:
 	rm -rf build
 	rm -f $(MKSUNXI)
 
 $(BUILD_DIR)/%.o : %.c
-	echo "  CC    $<"
+	echo "  CC    $@"
+	mkdir -p $(@D)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/%.opp : %.cpp
-	echo "  CXX   $<"
+	echo "  CXX   $@"
+	mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(MKSUNXI): $(COBJS)
-	$(CC) $(CFLAGS) $(BUILD_DIR)/mksunxi.o -o $(MKSUNXI)
+	echo "  LD    $@"
+	$(CC) $(CFLAGS) $(COBJS) -o $(MKSUNXI)


### PR DESCRIPTION
Build improvements:

add --gc-sections/-ffunction-sections/-fdata-sections so linker will remove unused functions.
as is, all functions are included in executable even if not called, adding these and defining an ENTRY() in the linker script will make ld remove unused functions producing smaller results.

add -MMD for proper deps of included files

build spi only, sd/mmc only, and combo images seperately into their own build directories